### PR TITLE
Using json standard library

### DIFF
--- a/paypaladaptive/api/endpoints.py
+++ b/paypaladaptive/api/endpoints.py
@@ -3,7 +3,7 @@
 from datetime import datetime, timedelta
 import logging
 
-from django.utils import simplejson as json
+import json
 
 from money.Money import Money
 

--- a/paypaladaptive/api/ipn/endpoints.py
+++ b/paypaladaptive/api/ipn/endpoints.py
@@ -1,7 +1,6 @@
 import logging
 import  urllib
 
-from django.utils import simplejson
 
 from dateutil.parser import parse
 from money.Money import Money, Currency

--- a/paypaladaptive/models.py
+++ b/paypaladaptive/models.py
@@ -6,7 +6,7 @@ from django.core.urlresolvers import reverse
 from django.db import models, transaction
 from django.utils.translation import ugettext_lazy as _
 from django.contrib.sites.models import Site
-from django.utils import simplejson as json
+import json
 
 from money.contrib.django.models.fields import MoneyField
 

--- a/paypaladaptive/models.py
+++ b/paypaladaptive/models.py
@@ -11,7 +11,7 @@ import json
 from money.contrib.django.models.fields import MoneyField
 
 import settings
-import apiautocommit
+import api
 
 
 try:

--- a/paypaladaptive/models.py
+++ b/paypaladaptive/models.py
@@ -11,7 +11,7 @@ import json
 from money.contrib.django.models.fields import MoneyField
 
 import settings
-import api
+import apiautocommit
 
 
 try:
@@ -168,7 +168,6 @@ class Payment(PaypalAdaptive):
         cancel_url = reverse('paypal-adaptive-payment-cancel', kwargs=kwargs)
         return "http://%s%s" % (current_site, cancel_url)
 
-    @transaction.autocommit
     def process(self, receivers, preapproval=None, **kwargs):
         """Process the payment"""
 
@@ -244,7 +243,6 @@ class Payment(PaypalAdaptive):
         
         return self.status in ['created', 'completed']
 
-    @transaction.autocommit
     def refund(self):
         """Refund this payment"""
 
@@ -362,7 +360,6 @@ class Preapproval(PaypalAdaptive):
                              kwargs=kwargs)
         return "http://%s%s" % (current_site, cancel_url)
 
-    @transaction.autocommit
     def process(self, **kwargs):
         """Process the preapproval"""
 
@@ -399,7 +396,6 @@ class Preapproval(PaypalAdaptive):
         
         return self.status == 'created'
         
-    @transaction.autocommit
     def cancel_preapproval(self):
         res, cancel = self.call(api.CancelPreapproval,
                                 preapproval_key=self.preapproval_key)
@@ -410,7 +406,6 @@ class Preapproval(PaypalAdaptive):
         self.save()
         return self.status == 'canceled'
         
-    @transaction.autocommit
     def mark_as_used(self):
         self.status = 'used'
         self.save()

--- a/paypaladaptive/views.py
+++ b/paypaladaptive/views.py
@@ -39,7 +39,6 @@ def render(request, template, template_vars=None):
 
 
 @login_required
-@transaction.autocommit
 def payment_cancel(request, payment_id, secret_uuid,
                    template="paypaladaptive/cancel.html"):
     """Handle incoming cancellation from paypal"""
@@ -56,7 +55,6 @@ def payment_cancel(request, payment_id, secret_uuid,
     return render(request, template, template_vars)
 
 
-@transaction.autocommit
 def payment_return(request, payment_id, secret_uuid,
                    template="paypaladaptive/return.html"):
     """
@@ -97,7 +95,6 @@ def payment_return(request, payment_id, secret_uuid,
     return render(request, template, template_vars)
 
 
-@transaction.autocommit
 def preapproval_cancel(request, preapproval_id,
                        template="paypaladaptive/cancel.html"):
     """Incoming preapproval cancellation from paypal"""
@@ -110,7 +107,6 @@ def preapproval_cancel(request, preapproval_id,
     return render(request, template, template_vars)
 
 
-@transaction.autocommit
 def preapproval_return(request, preapproval_id, secret_uuid,
                        template="paypaladaptive/return.html"):
     """
@@ -153,7 +149,6 @@ def preapproval_return(request, preapproval_id, secret_uuid,
 
 @csrf_exempt
 @require_POST
-@transaction.autocommit
 @takes_ipn
 def ipn(request, object_id, object_secret_uuid, ipn):
     """

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ setup(
     install_requires=[
         'Django>=1.4.3',
         'python-dateutil==2.1',
-        '-e git+https://github.com/kamotos/python-money.git#egg=money',
     ],
     extras_require={
         'delayed-updates': ['celery>=3.0.12'],

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     install_requires=[
         'Django>=1.4.3',
         'python-dateutil==2.1',
-        'python-money',
+        '-e git+https://github.com/kamotos/python-money.git#egg=money',
     ],
     extras_require={
         'delayed-updates': ['celery>=3.0.12'],

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         'delayed-updates': ['celery>=3.0.12'],
     },
     dependency_links=[
-        '-e git+http://github.com/poswald/python-money.git@29d3671e140307b958b51a32e6d1ac8553edc9e5#egg=python_money-dev'
+        '-e git+https://github.com/kamotos/python-money.git#egg=money'
     ],
     description='A pluggable Django application for integrating PayPal '
                 'Adaptive Payments',

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         'delayed-updates': ['celery>=3.0.12'],
     },
     dependency_links=[
-        '-e git+https://github.com/kamotos/python-money.git#egg=money'
+#        '-e git+https://github.com/kamotos/python-money.git#egg=money'
     ],
     description='A pluggable Django application for integrating PayPal '
                 'Adaptive Payments',


### PR DESCRIPTION
django.utils.json is deleted in django 1.8

The json standard library was added in Python 2.6. I think it's safe to use without requiring any other dependency.
